### PR TITLE
Fix a spelling mistake in the POD.

### DIFF
--- a/lib/Chemistry/Elements.pm
+++ b/lib/Chemistry/Elements.pm
@@ -673,7 +673,7 @@ simply pretend that there is a molar_mass method:
 
 	$element->molar_mass($MM); #add molar mass datum in $MM to object
 
-Similiarly, you can retrieve previously set values by not specifying
+Similarly, you can retrieve previously set values by not specifying
 an argument to your pretend method:
 
 	$datum = $element->molar_mass();


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Chemistry-Elements.
We thought you might be interested in it too.

    Description: Fix a spelling mistake in the POD.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2017-01-13
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libchemistry-elements-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
